### PR TITLE
#8 즐겨찾기 기능 고도화

### DIFF
--- a/PublicTransport/.idea/codeStyles/Project.xml
+++ b/PublicTransport/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/PublicTransport/.idea/codeStyles/Project.xml
+++ b/PublicTransport/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepository.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepository.kt
@@ -17,6 +17,8 @@ interface BusServiceRepository {
 
     fun getFavoriteBusStations(): Single<List<BusStation>>
 
+    fun getFavoriteBusStations(from: Int, to: Int): Single<List<BusStation>>
+
     fun updateFavoriteBusStations(busStations: List<BusStation>): Completable
 
     fun saveBusStation(busStation: BusStation): Completable

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepository.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepository.kt
@@ -20,4 +20,6 @@ interface BusServiceRepository {
     fun updateFavoriteBusStations(busStations: List<BusStation>): Completable
 
     fun saveBusStation(busStation: BusStation): Completable
+
+    fun getFavoriteBusStationLastIndex(): Single<Int>
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepository.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepository.kt
@@ -11,6 +11,8 @@ interface BusServiceRepository {
 
     fun getBusStationArrivalInfo(arsId: String): Single<List<ArrivalInfoItem>>
 
+    fun getFavoriteBusStation(id: Int): Single<BusStation>
+
     fun addFavoriteBusStation(busStation: BusStation): Completable
 
     fun deleteFavoriteBusStation(busStation: BusStation): Completable

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepositoryImpl.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepositoryImpl.kt
@@ -21,13 +21,8 @@ class BusServiceRepositoryImpl(
             .map { responseItems ->
                 BusStations(
                     stationName,
-                    responseItems.map {
-                        BusStation(
-                            it.arsId,
-                            it.stNm,
-                            -1,
-                            System.currentTimeMillis()
-                        )
+                    responseItems.mapIndexed { index, item ->
+                        BusStation(index, item.arsId, item.stNm, "")
                     }
                 )
             }
@@ -49,6 +44,9 @@ class BusServiceRepositoryImpl(
 
     override fun saveBusStation(busStation: BusStation): Completable =
         localDataSource.insertBusStation(busStation)
+
+    override fun getFavoriteBusStationLastIndex(): Single<Int> =
+        localDataSource.getLastBusStationIndex()
 
     companion object {
         private var instance: BusServiceRepositoryImpl? = null

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepositoryImpl.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepositoryImpl.kt
@@ -27,6 +27,9 @@ class BusServiceRepositoryImpl(
     override fun getBusStationArrivalInfo(arsId: String): Single<List<ArrivalInfoItem>> =
         remoteDataSource.getBusStationArrivalInfo(arsId)
 
+    override fun getFavoriteBusStation(id: Int): Single<BusStation> =
+        localDataSource.getFavoriteBusStation(id)
+
     override fun addFavoriteBusStation(busStation: BusStation) =
         localDataSource.insertBusStation(busStation)
 
@@ -43,7 +46,7 @@ class BusServiceRepositoryImpl(
         localDataSource.updateFavoriteBusStations(busStations)
 
     override fun saveBusStation(busStation: BusStation): Completable =
-        localDataSource.insertBusStation(busStation)
+        localDataSource.updateBusStation(busStation)
 
     override fun getFavoriteBusStationLastIndex(): Single<Int> =
         localDataSource.getLastBusStationIndex()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepositoryImpl.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/BusServiceRepositoryImpl.kt
@@ -18,13 +18,10 @@ class BusServiceRepositoryImpl(
 
     private fun getStationFromRemote(stationName: String): Single<BusStations> =
         remoteDataSource.getRemoteBusStationInfo(stationName)
-            .map { responseItems ->
-                BusStations(
-                    stationName,
-                    responseItems.mapIndexed { index, item ->
-                        BusStation(index, item.arsId, item.stNm, "")
-                    }
-                )
+            .map { items ->
+                BusStations(stationName, items.mapIndexed { index, item ->
+                    BusStation(index, item.arsId, item.stNm, "")
+                })
             }
 
     override fun getBusStationArrivalInfo(arsId: String): Single<List<ArrivalInfoItem>> =
@@ -38,6 +35,9 @@ class BusServiceRepositoryImpl(
 
     override fun getFavoriteBusStations(): Single<List<BusStation>> =
         localDataSource.getFavoriteBusStation()
+
+    override fun getFavoriteBusStations(from: Int, to: Int): Single<List<BusStation>> =
+        localDataSource.getFavoriteBusStationsFromTo(from, to)
 
     override fun updateFavoriteBusStations(busStations: List<BusStation>): Completable =
         localDataSource.updateFavoriteBusStations(busStations)

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSource.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSource.kt
@@ -5,6 +5,7 @@ import io.reactivex.Completable
 import io.reactivex.Single
 
 interface BusServiceLocalDataSource {
+
     fun getFavoriteBusStation(): Single<List<BusStation>>
 
     fun insertBusStation(busStation: BusStation): Completable
@@ -12,4 +13,6 @@ interface BusServiceLocalDataSource {
     fun deleteBusStation(busStation: BusStation): Completable
 
     fun updateFavoriteBusStations(busStations: List<BusStation>): Completable
+
+    fun getLastBusStationIndex(): Single<Int>
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSource.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSource.kt
@@ -8,6 +8,8 @@ interface BusServiceLocalDataSource {
 
     fun getFavoriteBusStation(): Single<List<BusStation>>
 
+    fun getFavoriteBusStationsFromTo(from: Int, to: Int): Single<List<BusStation>>
+
     fun insertBusStation(busStation: BusStation): Completable
 
     fun deleteBusStation(busStation: BusStation): Completable

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSource.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSource.kt
@@ -10,6 +10,8 @@ interface BusServiceLocalDataSource {
 
     fun getFavoriteBusStationsFromTo(from: Int, to: Int): Single<List<BusStation>>
 
+    fun getFavoriteBusStation(id: Int): Single<BusStation>
+
     fun insertBusStation(busStation: BusStation): Completable
 
     fun deleteBusStation(busStation: BusStation): Completable
@@ -17,4 +19,6 @@ interface BusServiceLocalDataSource {
     fun updateFavoriteBusStations(busStations: List<BusStation>): Completable
 
     fun getLastBusStationIndex(): Single<Int>
+
+    fun updateBusStation(busStation: BusStation): Completable
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSourceImpl.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSourceImpl.kt
@@ -14,6 +14,11 @@ class BusServiceLocalDataSourceImpl(
             .toSingle()
             .subscribeOn(Schedulers.io())
 
+    override fun getFavoriteBusStationsFromTo(from: Int, to: Int): Single<List<BusStation>> =
+        dao.getFavoriteBusStationFromTo(from, to)
+            .toSingle()
+            .subscribeOn(Schedulers.io())
+
     override fun insertBusStation(busStation: BusStation): Completable =
         dao.insertBusStation(busStation)
             .subscribeOn(Schedulers.io())

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSourceImpl.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSourceImpl.kt
@@ -14,6 +14,11 @@ class BusServiceLocalDataSourceImpl(
             .toSingle()
             .subscribeOn(Schedulers.io())
 
+    override fun getFavoriteBusStation(id: Int): Single<BusStation> =
+        dao.getFavoriteBusStation(id)
+            .toSingle()
+            .subscribeOn(Schedulers.io())
+
     override fun getFavoriteBusStationsFromTo(from: Int, to: Int): Single<List<BusStation>> =
         dao.getFavoriteBusStationFromTo(from, to)
             .toSingle()
@@ -28,13 +33,17 @@ class BusServiceLocalDataSourceImpl(
             .subscribeOn(Schedulers.io())
 
     override fun updateFavoriteBusStations(busStations: List<BusStation>): Completable =
-        dao.insertBusStations(busStations)
+        dao.updateBusStations(busStations)
             .subscribeOn(Schedulers.io())
 
     override fun getLastBusStationIndex(): Single<Int> =
         dao.getFavoriteBusStations()
             .toSingle()
             .flatMap { Single.just(it.size) }
+            .subscribeOn(Schedulers.io())
+
+    override fun updateBusStation(busStation: BusStation): Completable =
+        dao.updateBusStation(busStation)
             .subscribeOn(Schedulers.io())
 
     companion object {

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSourceImpl.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusServiceLocalDataSourceImpl.kt
@@ -23,10 +23,14 @@ class BusServiceLocalDataSourceImpl(
             .subscribeOn(Schedulers.io())
 
     override fun updateFavoriteBusStations(busStations: List<BusStation>): Completable =
-        Completable.concatArray(
-            dao.deleteAll(),
-            dao.insertBusStations(busStations)
-        ).subscribeOn(Schedulers.io())
+        dao.insertBusStations(busStations)
+            .subscribeOn(Schedulers.io())
+
+    override fun getLastBusStationIndex(): Single<Int> =
+        dao.getFavoriteBusStations()
+            .toSingle()
+            .flatMap { Single.just(it.size) }
+            .subscribeOn(Schedulers.io())
 
     companion object {
         private var instance: BusServiceLocalDataSource? = null

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusStationDao.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusStationDao.kt
@@ -8,7 +8,7 @@ import io.reactivex.Maybe
 @Dao
 interface BusStationDao {
 
-    @Query("SELECT * FROM busstations ORDER BY createTime ASC")
+    @Query("SELECT * FROM busstations ORDER BY id ASC")
     fun getFavoriteBusStations(): Maybe<List<BusStation>>
 
     @Query("DELETE FROM busstations")

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusStationDao.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusStationDao.kt
@@ -14,6 +14,9 @@ interface BusStationDao {
     @Query("SELECT * FROM busstations WHERE id BETWEEN :from AND :to")
     fun getFavoriteBusStationFromTo(from: Int, to: Int): Maybe<List<BusStation>>
 
+    @Query("SELECT * FROM busstations WHERE id = :id")
+    fun getFavoriteBusStation(id: Int): Maybe<BusStation>
+
     @Query("DELETE FROM busstations")
     fun deleteAll(): Completable
 
@@ -22,6 +25,12 @@ interface BusStationDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertBusStation(busStation: BusStation): Completable
+
+    @Update
+    fun updateBusStation(busStation: BusStation): Completable
+
+    @Update
+    fun updateBusStations(busStations: List<BusStation>): Completable
 
     @Delete
     fun deleteBusStations(busStation: BusStation): Completable

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusStationDao.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/BusStationDao.kt
@@ -11,6 +11,9 @@ interface BusStationDao {
     @Query("SELECT * FROM busstations ORDER BY id ASC")
     fun getFavoriteBusStations(): Maybe<List<BusStation>>
 
+    @Query("SELECT * FROM busstations WHERE id BETWEEN :from AND :to")
+    fun getFavoriteBusStationFromTo(from: Int, to: Int): Maybe<List<BusStation>>
+
     @Query("DELETE FROM busstations")
     fun deleteAll(): Completable
 

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/model/BusStation.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/data/local/model/BusStation.kt
@@ -5,14 +5,14 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "busstations")
 data class BusStation(
-    @PrimaryKey val arsId: String = "",
+    @PrimaryKey val id: Int,
+    val arsId: String = "",
     val stationName: String = "",
-    val tag: Int,
-    val createTime: Long
+    val tag: String
 ) {
 
     companion object {
-        fun empty(): BusStation = BusStation("", "", -1, System.currentTimeMillis())
+        fun empty(): BusStation = BusStation(0, "", "", "")
     }
 
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/TAG.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/TAG.kt
@@ -1,5 +1,0 @@
-package com.egiwon.publictransport.ui
-
-enum class TAG {
-    WORK, HOME, WORK_OFF, MART, TRIP, ETC
-}

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/arrivalinfo/BusStationArrivalPresenter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/arrivalinfo/BusStationArrivalPresenter.kt
@@ -27,25 +27,24 @@ class BusStationArrivalPresenter(
     }
 
     override fun addFavoriteBusStation(arsId: String) {
-        if (arrivalInfoList.isNotEmpty()) {
-            arrivalInfoList.find {
-                arsId == it.arsId
-            }?.let {
-                repository.addFavoriteBusStation(
-                    BusStation(
-                        it.arsId,
-                        it.stNm,
-                        -1,
-                        System.currentTimeMillis()
-                    )
-                )
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe {
-                        view.showResultAddFavoriteBusStation(it)
-                    }
-            }
-        }
+        repository.getFavoriteBusStationLastIndex()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { index ->
+                if (arrivalInfoList.isNotEmpty()) {
+                    arrivalInfoList
+                        .find { arsId == it.arsId }
+                        ?.let { addFavoriteBusStation(it, index) }
+                }
+            }.addDisposable()
     }
+
+    private fun addFavoriteBusStation(arrivalInfoItem: ArrivalInfoItem, id: Int) =
+        repository.addFavoriteBusStation(
+            BusStation(id, arrivalInfoItem.arsId, arrivalInfoItem.stNm, "")
+        ).observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                view.showResultAddFavoriteBusStation(arrivalInfoItem)
+            }.addDisposable()
 
     override fun checkFavoriteBusStation(arsId: String) {
         repository.getFavoriteBusStations()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/arrivalinfo/BusStationArrivalPresenter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/arrivalinfo/BusStationArrivalPresenter.kt
@@ -41,7 +41,8 @@ class BusStationArrivalPresenter(
     private fun addFavoriteBusStation(arrivalInfoItem: ArrivalInfoItem, id: Int) =
         repository.addFavoriteBusStation(
             BusStation(id, arrivalInfoItem.arsId, arrivalInfoItem.stNm, "")
-        ).observeOn(AndroidSchedulers.mainThread())
+        )
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 view.showResultAddFavoriteBusStation(arrivalInfoItem)
             }.addDisposable()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteAdapter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteAdapter.kt
@@ -4,17 +4,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import androidx.core.view.forEach
 import androidx.core.view.forEachIndexed
-import androidx.core.view.get
 import androidx.recyclerview.widget.RecyclerView
 import com.egiwon.publictransport.R
 import com.egiwon.publictransport.data.local.model.BusStation
 import com.egiwon.publictransport.ext.toStationId
 import com.google.android.material.chip.ChipGroup
-import kotlinx.android.synthetic.main.rv_fv_station_item.view.*
-import kotlinx.android.synthetic.main.rv_station_item.view.tv_station_arsId
-import kotlinx.android.synthetic.main.rv_station_item.view.tv_station_name
+import kotlinx.android.synthetic.main.rv_station_item.view.*
 import java.util.*
 
 typealias onGetItemListener = (position: Int) -> BusStation
@@ -41,13 +37,6 @@ class FavoriteAdapter(
             itemView.setOnClickListener {
                 onClick(favoriteStationList[adapterPosition])
             }
-
-            (itemView.chipgroup_fv_items as ChipGroup).forEach {
-                it.setOnClickListener { view ->
-                    onCheckedTag(adapterPosition, itemView.chipgroup_fv_items.getCheckedItem(view))
-                }
-
-            }
         }
 
     override fun getItemCount(): Int = favoriteStationList.size
@@ -66,17 +55,13 @@ class FavoriteAdapter(
     }
 
     fun moveItems(from: Int, to: Int) {
-        if (from < to) {
-            for (i in from until to) {
-                Collections.swap(favoriteStationList, i, i + 1)
-            }
-        } else {
-            for (i in to until from) {
-                Collections.swap(favoriteStationList, i, i + 1)
-            }
-        }
+        Collections.swap(favoriteStationList, from, to)
         notifyItemMoved(from, to)
-        onMoved(favoriteStationList.toMutableList())
+        if (from > to) {
+            onMoved(favoriteStationList.subList(to, from + 1))
+        } else {
+            onMoved(favoriteStationList.subList(from, to + 1))
+        }
     }
 
     fun setItems(list: List<BusStation>) {
@@ -97,9 +82,6 @@ class FavoriteAdapter(
         private fun View.bindItem(item: BusStation) {
             tv_station_name.text = item.stationName
             tv_station_arsId.text = item.arsId.toStationId()
-            if (item.tag >= 0) {
-                chipgroup_fv_items.check(chipgroup_fv_items[item.tag].id)
-            }
         }
 
     }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteAdapter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteAdapter.kt
@@ -4,26 +4,23 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import androidx.core.view.forEachIndexed
 import androidx.recyclerview.widget.RecyclerView
 import com.egiwon.publictransport.R
 import com.egiwon.publictransport.data.local.model.BusStation
 import com.egiwon.publictransport.ext.toStationId
-import com.google.android.material.chip.ChipGroup
 import kotlinx.android.synthetic.main.rv_station_item.view.*
 import java.util.*
+import kotlin.math.max
+import kotlin.math.min
 
 typealias onGetItemListener = (position: Int) -> BusStation
 typealias onClickListener = (BusStation) -> Unit
 typealias onRemoveItemListener = (position: Int) -> Unit
 typealias onMovedItemListener = (List<BusStation>) -> Unit
-typealias onCheckedTagListener = (adapterPosition: Int, chipsPosition: Int) -> Unit
-
 
 class FavoriteAdapter(
     private val onClick: onClickListener,
-    private val onMoved: onMovedItemListener,
-    private val onCheckedTag: onCheckedTagListener
+    private val onMoved: onMovedItemListener
 ) : RecyclerView.Adapter<FavoriteAdapter.FavoriteStationViewHolder>() {
 
     private val favoriteStationList = mutableListOf<BusStation>()
@@ -44,29 +41,23 @@ class FavoriteAdapter(
     override fun onBindViewHolder(holder: FavoriteStationViewHolder, position: Int) =
         holder.bind(favoriteStationList[position])
 
-    private fun ChipGroup.getCheckedItem(checkedView: View): Int {
-        forEachIndexed { index, view ->
-            if (view.id == checkedView.id) {
-                return index
-            }
-        }
-
-        return -1
-    }
-
     fun moveItems(from: Int, to: Int) {
         Collections.swap(favoriteStationList, from, to)
         notifyItemMoved(from, to)
-        if (from > to) {
-            onMoved(favoriteStationList.subList(to, from + 1))
-        } else {
-            onMoved(favoriteStationList.subList(from, to + 1))
-        }
+    }
+
+    fun onEndMovedItem(start: Int, end: Int) {
+        val subList = mutableListOf<BusStation>()
+        subList.addAll(favoriteStationList.subList(min(start, end), max(start, end)))
+        subList.add(favoriteStationList[max(start, end)])
+
+        onMoved(subList)
     }
 
     fun setItems(list: List<BusStation>) {
+        val sets = mutableSetOf<BusStation>().apply { addAll(list) }
         favoriteStationList.clear()
-        favoriteStationList.addAll(list)
+        favoriteStationList.addAll(sets)
         notifyDataSetChanged()
     }
 

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteAdapter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteAdapter.kt
@@ -8,7 +8,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.egiwon.publictransport.R
 import com.egiwon.publictransport.data.local.model.BusStation
 import com.egiwon.publictransport.ext.toStationId
-import kotlinx.android.synthetic.main.rv_station_item.view.*
+import kotlinx.android.synthetic.main.rv_fv_station_item.view.*
+import kotlinx.android.synthetic.main.rv_station_item.view.tv_station_arsId
+import kotlinx.android.synthetic.main.rv_station_item.view.tv_station_name
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -17,10 +19,12 @@ typealias onGetItemListener = (position: Int) -> BusStation
 typealias onClickListener = (BusStation) -> Unit
 typealias onRemoveItemListener = (position: Int) -> Unit
 typealias onMovedItemListener = (List<BusStation>) -> Unit
+typealias onClickTagListener = (id: Int, tag: String) -> Unit
 
 class FavoriteAdapter(
     private val onClick: onClickListener,
-    private val onMoved: onMovedItemListener
+    private val onMoved: onMovedItemListener,
+    private val onClickTag: onClickTagListener
 ) : RecyclerView.Adapter<FavoriteAdapter.FavoriteStationViewHolder>() {
 
     private val favoriteStationList = mutableListOf<BusStation>()
@@ -29,10 +33,25 @@ class FavoriteAdapter(
 
     val onRemoveItem: onRemoveItemListener = { favoriteStationList.removeAt(it) }
 
+    private var isExpand = false
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FavoriteStationViewHolder =
         FavoriteStationViewHolder(parent = parent).apply {
             itemView.setOnClickListener {
                 onClick(favoriteStationList[adapterPosition])
+            }
+
+            itemView.iv_expand.setOnClickListener {
+                isExpand = !isExpand
+
+                if (!isExpand) it.rotationX = 180f else it.rotationX = 0f
+                notifyItemChanged(adapterPosition)
+            }
+
+            itemView.iv_confirm.setOnClickListener {
+                itemView.tv_tag.text = itemView.et_tag.text.toString()
+                isExpand = false
+                onClickTag(favoriteStationList[adapterPosition].id, itemView.tv_tag.text.toString())
             }
         }
 
@@ -73,6 +92,10 @@ class FavoriteAdapter(
         private fun View.bindItem(item: BusStation) {
             tv_station_name.text = item.stationName
             tv_station_arsId.text = item.arsId.toStationId()
+            tv_tag.text = item.tag
+
+            et_tag.visibility = if (isExpand) View.VISIBLE else View.GONE
+            iv_confirm.visibility = et_tag.visibility
         }
 
     }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteContract.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteContract.kt
@@ -24,6 +24,6 @@ interface FavoriteContract : BaseContract {
 
         fun updateFavoriteStationListFromTo(subList: List<BusStation>)
 
-        fun requestBusStationTag(busStationIndex: Int, tagIndex: Int)
+        fun setFavoriteStationTag(id: Int, tag: String)
     }
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteContract.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteContract.kt
@@ -22,7 +22,7 @@ interface FavoriteContract : BaseContract {
 
         fun deleteFavoriteStationPermanently()
 
-        fun updateFavoriteStationList(busStations: List<BusStation>)
+        fun updateFavoriteStationListFromTo(subList: List<BusStation>)
 
         fun requestBusStationTag(busStationIndex: Int, tagIndex: Int)
     }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteFragment.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteFragment.kt
@@ -15,6 +15,7 @@ import com.egiwon.publictransport.data.remote.BusServiceRemoteDataSourceImpl
 import com.egiwon.publictransport.ui.arrivalinfo.BusStationArrivalActivity
 import com.egiwon.publictransport.ui.busstation.BusStationFragment.Companion.KEY_ITEM
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_favorite.*
 
 class FavoriteFragment
@@ -106,7 +107,8 @@ class FavoriteFragment
                     presenter.deleteFavoriteStationPermanently()
                 }
             }
-        }).show()
+        }).setAnchorView(requireActivity().nav_view)
+            .show()
     }
 
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteFragment.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteFragment.kt
@@ -21,6 +21,18 @@ import kotlinx.android.synthetic.main.fragment_favorite.*
 class FavoriteFragment
     : BaseFragment<FavoriteContract.Presenter>(R.layout.fragment_favorite), FavoriteContract.View {
 
+    override val presenter: FavoriteContract.Presenter by lazy {
+        FavoritePresenter(
+            this,
+            BusServiceRepositoryImpl.getInstance(
+                BusServiceRemoteDataSourceImpl.getInstance(),
+                BusServiceLocalDataSourceImpl.getInstance(
+                    BusStationDatabase.getInstance(requireContext()).busStationDao()
+                )
+            )
+        )
+    }
+
     private val onClick: onClickListener = {
 
         val intent = Intent(requireContext(), BusStationArrivalActivity::class.java).apply {
@@ -39,32 +51,15 @@ class FavoriteFragment
         }
     }
 
-    private val onMovedItemListener: onMovedItemListener = {
-        presenter.updateFavoriteStationList(it)
-    }
-
-    private val onCheckedTagListener: onCheckedTagListener =
-        { listPosition: Int, tagPosition: Int ->
-            presenter.requestBusStationTag(listPosition, tagPosition)
-        }
-
-    override val presenter: FavoriteContract.Presenter by lazy {
-        FavoritePresenter(
-            this,
-            BusServiceRepositoryImpl.getInstance(
-                BusServiceRemoteDataSourceImpl.getInstance(),
-                BusServiceLocalDataSourceImpl.getInstance(
-                    BusStationDatabase.getInstance(requireContext()).busStationDao()
-                )
-            )
-        )
+    private val onMovedItemListener: onMovedItemListener = { list ->
+        presenter.updateFavoriteStationListFromTo(list)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         with(rv_favorite_station) {
-            adapter = FavoriteAdapter(onClick, onMovedItemListener, onCheckedTagListener)
+            adapter = FavoriteAdapter(onClick, onMovedItemListener)
             setHasFixedSize(true)
             addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
             presenter.requestFavoriteStationList()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteFragment.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoriteFragment.kt
@@ -55,11 +55,15 @@ class FavoriteFragment
         presenter.updateFavoriteStationListFromTo(list)
     }
 
+    private val onClickTagListener: onClickTagListener = { id, tag ->
+        presenter.setFavoriteStationTag(id, tag)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         with(rv_favorite_station) {
-            adapter = FavoriteAdapter(onClick, onMovedItemListener)
+            adapter = FavoriteAdapter(onClick, onMovedItemListener, onClickTagListener)
             setHasFixedSize(true)
             addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
             presenter.requestFavoriteStationList()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoritePresenter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoritePresenter.kt
@@ -5,8 +5,6 @@ import com.egiwon.publictransport.data.BusServiceRepository
 import com.egiwon.publictransport.data.local.model.BusStation
 import com.egiwon.publictransport.data.response.Item
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.subjects.PublishSubject
-import java.util.concurrent.TimeUnit
 
 class FavoritePresenter(
     private val view: FavoriteContract.View,
@@ -17,28 +15,7 @@ class FavoritePresenter(
 
     private var deletedBusPosition: Int = 0
 
-    private val updateFavoriteListSubject = PublishSubject.create<List<BusStation>>()
-
     private var lastId = 0
-
-    init {
-        updateFavoriteListSubject
-            .debounce(1L, TimeUnit.SECONDS)
-            .subscribe { list ->
-
-                //                updateFavoriteBusStations(newList)
-            }.addDisposable()
-    }
-
-//    private fun <T>List<T>.swapId(): List<T> {
-//        val idList = li
-//    }
-
-    private fun updateFavoriteBusStations(busStations: List<BusStation>) =
-        repository.updateFavoriteBusStations(busStations)
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe()
-            .addDisposable()
 
     override fun requestFavoriteStationList() {
         repository.getFavoriteBusStations()
@@ -68,9 +45,20 @@ class FavoritePresenter(
             .addDisposable()
     }
 
-    override fun updateFavoriteStationList(busStations: List<BusStation>) {
-        updateFavoriteListSubject.onNext(busStations)
+    override fun updateFavoriteStationListFromTo(subList: List<BusStation>) {
+        val mutableList = subList.toMutableList()
+        mutableList.sortBy { it.id }
+
+        val updateList = mutableList.mapIndexed { index, bus ->
+            BusStation(bus.id, subList[index].arsId, subList[index].stationName, subList[index].tag)
+        }
+
+        repository.updateFavoriteBusStations(updateList)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe()
+            .addDisposable()
     }
+
 
     override fun requestBusStationTag(busStationIndex: Int, tagIndex: Int) {
         repository.getFavoriteBusStations()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoritePresenter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoritePresenter.kt
@@ -59,31 +59,21 @@ class FavoritePresenter(
             .addDisposable()
     }
 
-
-    override fun requestBusStationTag(busStationIndex: Int, tagIndex: Int) {
-        repository.getFavoriteBusStations()
+    override fun setFavoriteStationTag(id: Int, tag: String) {
+        repository.getFavoriteBusStation(id)
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { list ->
-                val busStation = BusStation(
-                    id = list[busStationIndex].id,
-                    arsId = list[busStationIndex].arsId,
-                    stationName = list[busStationIndex].stationName,
-                    tag = ""
+            .subscribe({
+                saveFavoriteBusStation(
+                    BusStation(id, it.arsId, it.stationName, tag)
                 )
-
-                val mutableList = list.toMutableList()
-                mutableList[busStationIndex] = busStation
-                setBusStationTag(mutableList[busStationIndex])
-            }
+            }, {})
             .addDisposable()
-
     }
 
-    private fun setBusStationTag(busStation: BusStation) {
+    private fun saveFavoriteBusStation(busStation: BusStation) =
         repository.saveBusStation(busStation)
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe()
+            .subscribe { requestFavoriteStationList() }
             .addDisposable()
-    }
 
 }

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoritePresenter.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/FavoritePresenter.kt
@@ -19,16 +19,20 @@ class FavoritePresenter(
 
     private val updateFavoriteListSubject = PublishSubject.create<List<BusStation>>()
 
+    private var lastId = 0
+
     init {
         updateFavoriteListSubject
             .debounce(1L, TimeUnit.SECONDS)
             .subscribe { list ->
-                val newList = list.map {
-                    BusStation(it.arsId, it.stationName, it.tag, System.currentTimeMillis() + 1)
-                }
-                updateFavoriteBusStations(newList)
+
+                //                updateFavoriteBusStations(newList)
             }.addDisposable()
     }
+
+//    private fun <T>List<T>.swapId(): List<T> {
+//        val idList = li
+//    }
 
     private fun updateFavoriteBusStations(busStations: List<BusStation>) =
         repository.updateFavoriteBusStations(busStations)
@@ -39,7 +43,10 @@ class FavoritePresenter(
     override fun requestFavoriteStationList() {
         repository.getFavoriteBusStations()
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { list -> view.showFavoriteStationList(list) }
+            .subscribe { list ->
+                view.showFavoriteStationList(list)
+                lastId = list.size
+            }
             .addDisposable()
     }
 
@@ -70,10 +77,10 @@ class FavoritePresenter(
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { list ->
                 val busStation = BusStation(
+                    id = list[busStationIndex].id,
                     arsId = list[busStationIndex].arsId,
                     stationName = list[busStationIndex].stationName,
-                    tag = tagIndex,
-                    createTime = list[busStationIndex].createTime
+                    tag = ""
                 )
 
                 val mutableList = list.toMutableList()

--- a/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/SwipeToDeleteCallback.kt
+++ b/PublicTransport/app/src/main/java/com/egiwon/publictransport/ui/favorite/SwipeToDeleteCallback.kt
@@ -12,6 +12,10 @@ class SwipeToDeleteCallback(
     swipeDirs: Int
 ) : ItemTouchHelper.SimpleCallback(dragDirs, swipeDirs) {
 
+    private var startIndex = 0
+    private var endIndex = 0
+    private var isSwipe = false
+
     override fun isLongPressDragEnabled(): Boolean = true
 
     override fun isItemViewSwipeEnabled(): Boolean = true
@@ -29,7 +33,27 @@ class SwipeToDeleteCallback(
     }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+        isSwipe = true
         onDelete(viewHolder.adapterPosition)
+    }
+
+    override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+        super.onSelectedChanged(viewHolder, actionState)
+        if (actionState == ItemTouchHelper.ACTION_STATE_DRAG) {
+            startIndex = viewHolder?.adapterPosition ?: 0
+            viewHolder?.itemView?.alpha = 0.75f
+        }
+    }
+
+    override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+        super.clearView(recyclerView, viewHolder)
+        if (isSwipe) {
+            isSwipe = false
+        } else {
+            endIndex = viewHolder.adapterPosition
+            viewHolder.itemView.alpha = 1f
+            (recyclerView.adapter as? FavoriteAdapter)?.onEndMovedItem(startIndex, endIndex)
+        }
     }
 
     override fun onChildDraw(

--- a/PublicTransport/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/PublicTransport/app/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z" />
+</vector>

--- a/PublicTransport/app/src/main/res/layout/rv_fv_station_item.xml
+++ b/PublicTransport/app/src/main/res/layout/rv_fv_station_item.xml
@@ -3,22 +3,24 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="72dp"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
     <View
+        android:id="@+id/bar"
         android:layout_width="10dp"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:layout_margin="4dp"
         android:background="@android:color/holo_orange_dark"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="16dp"
-        android:orientation="vertical">
+        android:layout_height="0dp"
+        android:padding="16dp"
+        app:layout_constraintStart_toEndOf="@id/bar"
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/tv_station_name"
@@ -45,6 +47,48 @@
             app:layout_constraintTop_toBottomOf="@id/tv_station_name"
             tools:text="12-345" />
 
+        <TextView
+            android:id="@+id/tv_tag"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:singleLine="true"
+            android:textSize="12sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_station_arsId"
+            tools:text="#출근" />
+
+        <ImageView
+            android:id="@+id/iv_expand"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:rotationX="0"
+            android:src="@drawable/ic_arrow_down"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_station_name" />
+
+        <EditText
+            android:id="@+id/et_tag"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:autofillHints="false"
+            android:hint="@string/input_tag"
+            android:inputType="text"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toStartOf="@id/iv_confirm"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_tag" />
+
+        <ImageView
+            android:id="@+id/iv_confirm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_fill_star_24px"
+            app:layout_constraintBottom_toBottomOf="@id/et_tag"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/et_tag" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/PublicTransport/app/src/main/res/layout/rv_fv_station_item.xml
+++ b/PublicTransport/app/src/main/res/layout/rv_fv_station_item.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="128dp"
+    android:layout_height="72dp"
     android:orientation="vertical">
 
     <View
@@ -33,63 +33,6 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="가양6단지 아파트 " />
 
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/chipgroup_fv_items"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_station_name"
-            app:singleLine="true"
-            app:singleSelection="true">
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_work"
-                style="@style/Widget.MaterialComponents.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/chip_work"
-                tools:text="work" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_home"
-                style="@style/Widget.MaterialComponents.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/chip_home"
-                tools:text="home" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_off_work"
-                style="@style/Widget.MaterialComponents.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/chip_off_work"
-                tools:text="off work" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_mart"
-                style="@style/Widget.MaterialComponents.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/chip_mart" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_trip"
-                style="@style/Widget.MaterialComponents.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/chip_trip" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_etc"
-                style="@style/Widget.MaterialComponents.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/chip_etc" />
-
-        </com.google.android.material.chip.ChipGroup>
-
-
         <TextView
             android:id="@+id/tv_station_arsId"
             android:layout_width="wrap_content"
@@ -99,7 +42,7 @@
             android:textAlignment="textStart"
             android:textSize="12sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/chipgroup_fv_items"
+            app:layout_constraintTop_toBottomOf="@id/tv_station_name"
             tools:text="12-345" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PublicTransport/app/src/main/res/values/strings.xml
+++ b/PublicTransport/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="chip_mart">마트</string>
     <string name="chip_trip">여행</string>
     <string name="chip_etc">기타</string>
+    <string name="input_tag">태그를 입력해주세요</string>
 </resources>

--- a/PublicTransport/build.gradle
+++ b/PublicTransport/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
         // NOTE: Do not place your application dependencies here; they belong

--- a/PublicTransport/gradle/wrapper/gradle-wrapper.properties
+++ b/PublicTransport/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 07 22:42:10 KST 2020
+#Thu Feb 27 13:54:00 KST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
1. 기존의 리싸이클러 아이템 move 방식 변경 
 - 전체 삭제 전체 삽입 에서 바뀐 부분 만 업데이트 하도록 변경

2. 즐겨찾기 태그 기능 개선
 - expand 아이템으로 변경하여 추가 할 수 있도록 수정